### PR TITLE
게시글 조회수 구현

### DIFF
--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -47,6 +47,7 @@ create table article
     modified_by        bigint comment '게시글 수정자 아이디',
     modified_date_time datetime default now() comment '게시글 수정 시간',
     is_deleted         boolean default false comment '게시글 삭제 유무',
+    views              bigint not null default 0 comment '게시글 조회수',
     primary key (id),
     foreign key (category_id) references category (id)
 ) default charset=utf8mb4 collate=utf8mb4_general_ci;

--- a/frontend/components/article/articles.tsx
+++ b/frontend/components/article/articles.tsx
@@ -13,6 +13,7 @@ async function getArticles() {
 
 export default async function Articles() {
     const articles = await getArticles();
+    console.log(articles);
     return (
         <div>
             {articles.map((article: ArticleSimpleResponse) => (

--- a/frontend/components/article/client-article.tsx
+++ b/frontend/components/article/client-article.tsx
@@ -32,6 +32,10 @@ export default function ClientArticle({article}: { article: ArticleSimpleRespons
                         <p className="font-semibold text-default-400 text-small">{article.likeCount}</p>
                         <p className="text-default-400 text-small">좋아요</p>
                     </div>
+                    <div className="flex gap-1">
+                        <p className="font-semibold text-default-400 text-small">{article.views}</p>
+                        <p className=" text-default-400 text-small">조회수</p>
+                    </div>
                 </CardFooter>
             </Card>
         </div>

--- a/frontend/model/dto/response/ArticleSimpleResponse.ts
+++ b/frontend/model/dto/response/ArticleSimpleResponse.ts
@@ -4,7 +4,8 @@ interface ArticleSimpleResponse {
     category: string;
     commentCount: number;
     likeCount: number;
-    createdDateTime: string,
+    views: number;
+    createdDateTime: string;
 }
 
 export default ArticleSimpleResponse;

--- a/src/main/kotlin/com/sat/board/command/application/ArticleOfViewsCacheInitializer.kt
+++ b/src/main/kotlin/com/sat/board/command/application/ArticleOfViewsCacheInitializer.kt
@@ -1,0 +1,24 @@
+package com.sat.board.command.application
+
+import com.sat.board.query.ArticleQueryService
+import com.sat.common.domain.RedisCacheName
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.data.redis.core.DefaultTypedTuple
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class ArticleOfViewsCacheInitializer(
+    private val articleQueryService: ArticleQueryService,
+    private val redisTemplate: RedisTemplate<String, Any>
+): InitializingBean {
+    override fun afterPropertiesSet() {
+        val articlesOfViews = articleQueryService.getArticlesOfViews()
+        val articleViewsZSetOps = redisTemplate.opsForZSet()
+
+        val tupleSet = articlesOfViews.map {
+            DefaultTypedTuple(it.articleId as Any, it.views.toDouble())
+        }.toSet()
+        articleViewsZSetOps.add(RedisCacheName.ARTICLE_RANKING.key, tupleSet)
+    }
+}

--- a/src/main/kotlin/com/sat/board/command/application/ArticleOfViewsCacheInitializer.kt
+++ b/src/main/kotlin/com/sat/board/command/application/ArticleOfViewsCacheInitializer.kt
@@ -16,9 +16,11 @@ class ArticleOfViewsCacheInitializer(
         val articlesOfViews = articleQueryService.getArticlesOfViews()
         val articleViewsZSetOps = redisTemplate.opsForZSet()
 
-        val tupleSet = articlesOfViews.map {
-            DefaultTypedTuple(it.articleId as Any, it.views.toDouble())
-        }.toSet()
-        articleViewsZSetOps.add(RedisCacheName.ARTICLE_RANKING.key, tupleSet)
+        if (articlesOfViews.isEmpty()) {
+            val tupleSet = articlesOfViews.map {
+                DefaultTypedTuple(it.articleId as Any, it.views.toDouble())
+            }.toSet()
+            articleViewsZSetOps.add(RedisCacheName.ARTICLE_RANKING.key, tupleSet)
+        }
     }
 }

--- a/src/main/kotlin/com/sat/board/command/application/ArticleOfViewsCacheInitializer.kt
+++ b/src/main/kotlin/com/sat/board/command/application/ArticleOfViewsCacheInitializer.kt
@@ -16,7 +16,7 @@ class ArticleOfViewsCacheInitializer(
         val articlesOfViews = articleQueryService.getArticlesOfViews()
         val articleViewsZSetOps = redisTemplate.opsForZSet()
 
-        if (articlesOfViews.isEmpty()) {
+        if (articlesOfViews.isNotEmpty()) {
             val tupleSet = articlesOfViews.map {
                 DefaultTypedTuple(it.articleId as Any, it.views.toDouble())
             }.toSet()

--- a/src/main/kotlin/com/sat/board/command/domain/article/Article.kt
+++ b/src/main/kotlin/com/sat/board/command/domain/article/Article.kt
@@ -14,6 +14,7 @@ class Article(
     var category: Category,
     id: Long = 0L,
 ) : BaseEntity(id) {
+    var views: Long = 0
     var isDeleted: Boolean = false
 
     fun update(that: ArticleUpdateDto) {

--- a/src/main/kotlin/com/sat/board/command/domain/article/Article.kt
+++ b/src/main/kotlin/com/sat/board/command/domain/article/Article.kt
@@ -1,16 +1,15 @@
 package com.sat.board.command.domain.article
 
 import com.sat.common.BaseEntity
-import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.*
 
 @Entity
 class Article(
+    @Column(nullable = false)
     var title: String,
+    @Column(nullable = false)
     var content: String,
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "category_id")
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "category_id", nullable = false)
     var category: Category,
     id: Long = 0L,
 ) : BaseEntity(id) {

--- a/src/main/kotlin/com/sat/board/command/domain/article/ArticleCacheRepository.kt
+++ b/src/main/kotlin/com/sat/board/command/domain/article/ArticleCacheRepository.kt
@@ -3,4 +3,5 @@ package com.sat.board.command.domain.article
 interface ArticleCacheRepository {
     fun increase(articleId: Long)
     fun getViews(articleId: Long): Long
+    fun getAllArticleViews(): Map<Long, Long>
 }

--- a/src/main/kotlin/com/sat/board/command/domain/article/ArticleCacheRepository.kt
+++ b/src/main/kotlin/com/sat/board/command/domain/article/ArticleCacheRepository.kt
@@ -1,0 +1,6 @@
+package com.sat.board.command.domain.article
+
+interface ArticleCacheRepository {
+    fun increase(articleId: Long)
+    fun getViews(articleId: Long): Long
+}

--- a/src/main/kotlin/com/sat/board/command/domain/article/CategoryName.kt
+++ b/src/main/kotlin/com/sat/board/command/domain/article/CategoryName.kt
@@ -5,7 +5,7 @@ import jakarta.persistence.Embeddable
 
 @Embeddable
 data class CategoryName(
-    @Column(name = "name")
+    @Column(name = "name", nullable = false)
     val value: String,
 ) {
     init {

--- a/src/main/kotlin/com/sat/board/command/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/sat/board/command/domain/comment/Comment.kt
@@ -2,11 +2,14 @@ package com.sat.board.command.domain.comment
 
 import com.sat.board.command.application.CommentUpdateCommand
 import com.sat.common.BaseEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 
 @Entity
 class Comment(
+    @Column(nullable = false)
     val articleId: Long,
+    @Column(nullable = false)
     var content: String,
     var parentId: Long? = null,
     id: Long = 0L,

--- a/src/main/kotlin/com/sat/board/command/domain/like/Like.kt
+++ b/src/main/kotlin/com/sat/board/command/domain/like/Like.kt
@@ -1,11 +1,14 @@
 package com.sat.board.command.domain.like
 
 import com.sat.common.BaseEntity
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
 
 @Table(name = "LIKES")
 @Entity
 class Like(
+    @Column(nullable = false)
     val articleId: Long,
     id: Long = 0L,
 ) : BaseEntity(id)

--- a/src/main/kotlin/com/sat/board/command/infra/RedisArticleCacheRepository.kt
+++ b/src/main/kotlin/com/sat/board/command/infra/RedisArticleCacheRepository.kt
@@ -18,4 +18,13 @@ class RedisArticleCacheRepository(
         val valueOperations = redisTemplate.opsForZSet()
         return valueOperations.score(RedisCacheName.ARTICLE_RANKING.key, articleId)!!.toLong()
     }
+
+    override fun getAllArticleViews(): Map<Long, Long> {
+        val valueOperations = redisTemplate.opsForZSet()
+        val tuples = valueOperations.rangeWithScores(RedisCacheName.ARTICLE_RANKING.key, 0, -1)
+
+        return tuples?.associate { tuple ->
+            (tuple.value as Int).toLong() to tuple.score!!.toLong()
+        } ?: emptyMap()
+    }
 }

--- a/src/main/kotlin/com/sat/board/command/infra/RedisArticleCacheRepository.kt
+++ b/src/main/kotlin/com/sat/board/command/infra/RedisArticleCacheRepository.kt
@@ -1,0 +1,21 @@
+package com.sat.board.command.infra
+
+import com.sat.board.command.domain.article.ArticleCacheRepository
+import com.sat.common.domain.RedisCacheName
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class RedisArticleCacheRepository(
+    private val redisTemplate: RedisTemplate<String, Any>,
+): ArticleCacheRepository {
+    override fun increase(articleId: Long) {
+        val valueOperations = redisTemplate.opsForZSet()
+        valueOperations.incrementScore(RedisCacheName.ARTICLE_RANKING.key, articleId, 1.0)
+    }
+
+    override fun getViews(articleId: Long): Long {
+        val valueOperations = redisTemplate.opsForZSet()
+        return valueOperations.score(RedisCacheName.ARTICLE_RANKING.key, articleId)!!.toLong()
+    }
+}

--- a/src/main/kotlin/com/sat/board/query/ArticleDtos.kt
+++ b/src/main/kotlin/com/sat/board/query/ArticleDtos.kt
@@ -22,7 +22,9 @@ data class ArticleWithCountQuery(
     val commentCount: Long,
     val likeCount: Long,
     val createdDateTime: LocalDateTime,
-)
+) {
+    var views: Long = 0
+}
 
 data class ArticleWithViews(
     val articleId: Long,

--- a/src/main/kotlin/com/sat/board/query/ArticleDtos.kt
+++ b/src/main/kotlin/com/sat/board/query/ArticleDtos.kt
@@ -12,6 +12,7 @@ data class ArticleQuery(
     val createdByName: String,
 ) {
     var hasLike: Boolean by OnceWriteProperty(false)
+    var views: Long = 0
 }
 
 data class ArticleWithCountQuery(

--- a/src/main/kotlin/com/sat/board/query/ArticleDtos.kt
+++ b/src/main/kotlin/com/sat/board/query/ArticleDtos.kt
@@ -24,3 +24,9 @@ data class ArticleWithCountQuery(
     val createdDateTime: LocalDateTime,
 )
 
+data class ArticleWithViews(
+    val articleId: Long,
+    val views: Long,
+)
+
+

--- a/src/main/kotlin/com/sat/board/query/ArticleQueryService.kt
+++ b/src/main/kotlin/com/sat/board/query/ArticleQueryService.kt
@@ -48,7 +48,7 @@ class ArticleQueryService(
     }
 
     fun getAll(memberId: Long? = null): List<ArticleWithCountQuery> {
-        return articleRepository.findNotNullAll {
+        val articles = articleRepository.findNotNullAll {
             selectNew<ArticleWithCountQuery>(
                 path(Article::id),
                 path(Article::title),
@@ -69,6 +69,12 @@ class ArticleQueryService(
             ).orderBy(
                 path(Article::id).desc()
             )
+        }
+
+        val articlesWithViews = articleCacheRepository.getAllArticleViews()
+        return articles.map {
+            it.views = articlesWithViews[it.id] ?: 0
+            it
         }
     }
 

--- a/src/main/kotlin/com/sat/board/query/ArticleWithViews.kt
+++ b/src/main/kotlin/com/sat/board/query/ArticleWithViews.kt
@@ -1,6 +1,0 @@
-package com.sat.board.query
-
-data class ArticleWithViews(
-    val articleId: Long,
-    val views: Long,
-)

--- a/src/main/kotlin/com/sat/board/query/ArticleWithViews.kt
+++ b/src/main/kotlin/com/sat/board/query/ArticleWithViews.kt
@@ -1,0 +1,6 @@
+package com.sat.board.query
+
+data class ArticleWithViews(
+    val articleId: Long,
+    val views: Long,
+)

--- a/src/main/kotlin/com/sat/common/domain/RedisCacheName.kt
+++ b/src/main/kotlin/com/sat/common/domain/RedisCacheName.kt
@@ -3,5 +3,6 @@ package com.sat.common.domain
 enum class RedisCacheName(
     val key: String,
 ) {
-    RANKING("ranking"),
+    POINT_RANKING("point-ranking"),
+    ARTICLE_RANKING("article-ranking"),
 }

--- a/src/main/kotlin/com/sat/user/command/application/PointCacheInitializer.kt
+++ b/src/main/kotlin/com/sat/user/command/application/PointCacheInitializer.kt
@@ -16,9 +16,11 @@ class PointCacheInitializer(
         val totalPointsOfMembers = pointQueryService.getTotalPointsOfMembers()
         val pointRankingZSetOps = redisTemplate.opsForZSet()
 
-        val tupleSet = totalPointsOfMembers.map {
-            DefaultTypedTuple(it.memberId as Any, it.point.toDouble())
-        }.toSet()
-        pointRankingZSetOps.add(RedisCacheName.POINT_RANKING.key, tupleSet)
+        if (totalPointsOfMembers.isNotEmpty()) {
+            val tupleSet = totalPointsOfMembers.map {
+                DefaultTypedTuple(it.memberId as Any, it.point.toDouble())
+            }.toSet()
+            pointRankingZSetOps.add(RedisCacheName.POINT_RANKING.key, tupleSet)
+        }
     }
 }

--- a/src/main/kotlin/com/sat/user/command/application/PointCacheInitializer.kt
+++ b/src/main/kotlin/com/sat/user/command/application/PointCacheInitializer.kt
@@ -19,6 +19,6 @@ class PointCacheInitializer(
         val tupleSet = totalPointsOfMembers.map {
             DefaultTypedTuple(it.memberId as Any, it.point.toDouble())
         }.toSet()
-        pointRankingZSetOps.add(RedisCacheName.RANKING.key, tupleSet)
+        pointRankingZSetOps.add(RedisCacheName.POINT_RANKING.key, tupleSet)
     }
 }

--- a/src/main/kotlin/com/sat/user/command/domain/member/LoginHistory.kt
+++ b/src/main/kotlin/com/sat/user/command/domain/member/LoginHistory.kt
@@ -1,14 +1,13 @@
 package com.sat.user.command.domain.member
 
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
+import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity
 class LoginHistory(
+    @Column(nullable = false)
     val memberId: Long,
+    @Column(nullable = false)
     val loginDateTime: LocalDateTime,
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,

--- a/src/main/kotlin/com/sat/user/command/domain/member/Member.kt
+++ b/src/main/kotlin/com/sat/user/command/domain/member/Member.kt
@@ -1,16 +1,20 @@
 package com.sat.user.command.domain.member
 
 import com.sat.common.BaseEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 
 @Entity
 class Member(
+    @Column(nullable = false)
     val name: String,
+    @Column(nullable = false)
     var nickname: String,
+    @Column(nullable = false)
     val email: String,
-    @OneToOne @JoinColumn(name = "role_id")
+    @OneToOne @JoinColumn(name = "role_id", nullable = false)
     val role: Role,
     id: Long = 0L,
 ) : BaseEntity(id) {

--- a/src/main/kotlin/com/sat/user/command/domain/point/Point.kt
+++ b/src/main/kotlin/com/sat/user/command/domain/point/Point.kt
@@ -8,8 +8,9 @@ import java.time.LocalDateTime
 @EntityListeners(AuditingEntityListener::class)
 @Entity
 class Point(
+    @Column(nullable = false)
     val memberId: Long,
-    @Enumerated(EnumType.STRING)
+    @Column(nullable = false) @Enumerated(EnumType.STRING)
     val type: PointType,
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,

--- a/src/main/kotlin/com/sat/user/command/infra/RedisPointCacheRepository.kt
+++ b/src/main/kotlin/com/sat/user/command/infra/RedisPointCacheRepository.kt
@@ -11,6 +11,6 @@ class RedisPointCacheRepository(
 ) : PointCacheRepository {
     override fun increase(memberId: Long, point: Int) {
         val valueOperations = redisTemplate.opsForZSet()
-        valueOperations.incrementScore(RedisCacheName.RANKING.key, memberId, point.toDouble())
+        valueOperations.incrementScore(RedisCacheName.POINT_RANKING.key, memberId, point.toDouble())
     }
 }

--- a/src/main/kotlin/com/sat/user/query/PointQueryService.kt
+++ b/src/main/kotlin/com/sat/user/query/PointQueryService.kt
@@ -66,15 +66,15 @@ class PointQueryService(
 
     fun getPoint(memberId: Long): Int {
         val points = redisTemplate.opsForZSet()
-        return points.score(RedisCacheName.RANKING.key, memberId)!!.toInt()
+        return points.score(RedisCacheName.POINT_RANKING.key, memberId)!!.toInt()
     }
 
     fun getPointRanking(): List<PointQuery> {
         val pointRankingZSetOps = redisTemplate.opsForZSet()
-        val ranking = pointRankingZSetOps.reverseRangeWithScores(RedisCacheName.RANKING.key, 0, 9)
+        val POINT_RANKING = pointRankingZSetOps.reverseRangeWithScores(RedisCacheName.POINT_RANKING.key, 0, 9)
                 ?: throw IllegalStateException("포인트 랭킹 정보를 찾을 수 없습니다.")
 
-        val pointRankings = ranking.map { PointQuery(memberId = it.value as Long, point = it.score?.toInt() ?: 0) }
+        val pointRankings = POINT_RANKING.map { PointQuery(memberId = it.value as Long, point = it.score?.toInt() ?: 0) }
         val memberIds = pointRankings.map { it.memberId }
         val members = memberQueryService.getByIds(memberIds)
 


### PR DESCRIPTION
- 조회수는 redis를 사용해서 가져온다.
  - redis에 적재하는 데이터는 일정기간을 두고 할거고 만약 옛날 데이터가 조회된다면 그 데이터는 그냥 디비에서 바로 가져오도록한다
  - 그리고 따로 redis에 적재하지 않는다
- redis에 저장된 조회수를 일정 시간마다 db에 반영해준다.
- 조회수 순으로 게시글 랭킹을 만들어준다.